### PR TITLE
chore: bare link in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Specifications in the repository are subject to the **Community Specification License 1.0** available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+Specifications in the repository are subject to the **Community Specification License 1.0** available at https://github.com/CommunitySpecification/1.0.
 
 If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise designated. In the case of any conflict or confusion within this specification repository between the Community Specification License and the MIT or other designated license, the terms of the Community Specification License shall apply.
 


### PR DESCRIPTION
The license view in GitHub currently renders in such a way that the link to the license is broken.

<img width="1144" height="391" alt="Screenshot 2025-07-19 at 10 07 45 AM" src="https://github.com/user-attachments/assets/6e5baf22-3d7d-4377-92ea-e0a66a50b403" />

This change aims to correct that issue.
