### PR TITLE
ci: replace GH_AUTH_TOKEN PAT with Octo STS federation in baseline scanner

### DIFF
--- a/.github/chainguard/baseline-scanner.sts.yaml
+++ b/.github/chainguard/baseline-scanner.sts.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/octo-sts/app/refs/heads/main/pkg/octosts/octosts.TrustPolicy.json
+#
+# Octo STS trust policy for the OSPS Baseline Scanner workflow.
+# Allows GitHub Actions runs on the main branch of this repository to
+# federate for a short-lived GitHub App token, replacing the long-lived
+# GH_AUTH_TOKEN PAT. See .github/workflows/baseline.yaml.
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:ossf/security-insights:ref:refs/heads/main
+
+permissions:
+  metadata: read # Repository and organization metadata, branch rules
+  contents: read # Repo contents, languages, releases, security policy
+  administration: read # Branch protection rule via GraphQL
+  checks: read # Check suites/runs on the latest commit
+  statuses: read # Classic commit status API

--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -15,6 +15,7 @@ jobs:
 
     permissions:
       contents: read # Clone the repository
+      id-token: write # Federate with Octo STS for a short-lived GitHub App token
       security-events: write # Required for SARIF upload
 
     steps:
@@ -27,12 +28,22 @@ jobs:
         with:
           persist-credentials: false
 
+      # Exchanges this workflow's OIDC identity for a short-lived GitHub App
+      # token, per the trust policy in .github/chainguard/baseline-scanner.sts.yaml.
+      # Replaces the expiring GH_AUTH_TOKEN PAT.
+      - name: Federate with Octo STS
+        id: octo-sts
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        with:
+          scope: ${{ github.repository }}
+          identity: baseline-scanner
+
       - name: Run Baseline Action
         uses: revanite-io/osps-baseline-action@b7d860b68755627c30ab692473511c90daee3ae8 # v1.3.4
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
-          token: ${{ secrets.GH_AUTH_TOKEN }}
+          token: ${{ steps.octo-sts.outputs.token }}
           catalog: "osps-baseline"
           upload-sarif: "true"
 


### PR DESCRIPTION
Relates to #162

## What/Why

The OSPS Baseline Scanner has broken twice on PAT (Personal Access Token) availability: `PVTR_GITHUB_TOKEN` expired (#162), and now `GH_AUTH_TOKEN` is not available to this repo (see #194 for the diagnosis). This swaps the PAT for [Octo STS](https://github.com/octo-sts/app) federation: the workflow exchanges its OIDC identity for a short-lived GitHub App token minted against a trust policy checked into this repo, so there is no long-lived secret left to expire, rotate, or leak. Unlike the workflow `GITHUB_TOKEN` (#194), the federated token carries `administration: read`, so the OSPS-AC-03 branch protection checks remain fully observable. Mirrors gemaraproj/go-gemara#116.

## Proof it works

Structural verification: actionlint passes and the trust policy follows the Octo STS TrustPolicy schema (same shape as the go-gemara policy). The [Octo STS App](https://github.com/apps/octo-sts) is now installed on the `ossf` org, so the remaining end-to-end test is a `workflow_dispatch` run from `main` after merge (the trust policy subject only matches `refs/heads/main`).

## Risk + AI role

Low. Scheduled scan workflow and a new trust policy file only. AI-generated, mirroring the go-gemara change.

## Review focus

- Trust policy permission set (`.github/chainguard/baseline-scanner.sts.yaml`), derived from the scanner's actual API calls. May need adjusting after a live run.
- Whether ossf wants repo-level trust policies or a central org-level policy in `ossf/.github` instead.