### PR TITLE
Improve editor responsiveness on narrow screens

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI Checks
 
 on:
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -37,8 +38,14 @@ jobs:
       - name: Install editor test dependencies
         run: npm ci
 
+      - name: Install browser test dependencies
+        run: npx playwright install --with-deps chromium
+
       - name: Test editor
         run: make testeditor
+
+      - name: Test editor in browser
+        run: npm run test:browser
 
       - name: Validate schema.cue
         run: make lintcue

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ cmd/*/cue2openapi
 cmd/*/openapi2md
 docs/_site/
 node_modules/
+test-results/
 .DS_Store

--- a/docs/_includes/nav-items.html
+++ b/docs/_includes/nav-items.html
@@ -2,8 +2,8 @@
   {%- if site.navigation -%}
     {%- for nav_item in site.navigation -%}
       {%- if nav_item.children -%}
-        <div class="nav-dropdown">
-          <span class="nav-item nav-dropdown-toggle">{{ nav_item.name | escape }}</span>
+        <details class="nav-dropdown">
+          <summary class="nav-item nav-dropdown-toggle">{{ nav_item.name | escape }}</summary>
           <div class="nav-dropdown-content">
             {%- for child in nav_item.children -%}
               {%- assign child_page = site.pages | where: "path", child.path | first -%}
@@ -16,7 +16,7 @@
               {%- endif -%}
             {%- endfor -%}
           </div>
-        </div>
+        </details>
       {%- else -%}
         {%- assign hyperpage = site.pages | where: "path", nav_item.path | first -%}
         {%- if hyperpage -%}
@@ -41,4 +41,3 @@
     {%- endfor %}
   {%- endif -%}
 </div>
-

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -105,6 +105,11 @@ a:active {
 
 .nav-dropdown-toggle {
   cursor: pointer;
+  list-style: none;
+}
+
+.nav-dropdown-toggle::-webkit-details-marker {
+  display: none;
 }
 
 .nav-dropdown-toggle:hover {
@@ -124,7 +129,8 @@ a:active {
   margin-top: 4px;
 }
 
-.nav-dropdown:hover .nav-dropdown-content {
+.nav-dropdown[open] .nav-dropdown-content,
+.nav-dropdown:focus-within .nav-dropdown-content {
   display: block;
 }
 
@@ -138,6 +144,38 @@ a:active {
 .nav-dropdown-item:hover {
   background-color: #f1f1f1;
   text-decoration: underline;
+}
+
+@media screen and (max-width: 600px) {
+  .header-wrapper {
+    padding-top: 12px;
+  }
+
+  .site-logo img {
+    height: 64px;
+  }
+
+  .site-title {
+    font-size: 1.1rem;
+  }
+
+  .nav-items {
+    display: block;
+  }
+
+  .nav-items > .nav-item,
+  .nav-dropdown {
+    display: block;
+    margin-bottom: 8px;
+  }
+
+  .nav-dropdown-content {
+    position: static;
+    min-width: 0;
+    box-shadow: none;
+    border-left: 3px solid #45208c;
+    margin: 4px 0 0 8px;
+  }
 }
 
 /* Radio-driven tabs (no JS). The radios are visually hidden but remain
@@ -208,4 +246,3 @@ a:active {
 #tab-multi:checked ~ #panel-multi {
   display: block;
 }
-

--- a/docs/editor/css/editor.css
+++ b/docs/editor/css/editor.css
@@ -6,14 +6,15 @@
   --color-primary-visited: #604693;
   --color-primary-hover: #170D34;
   --color-accent: #04ee5f;
-  --color-error: #dc3545;
+  --color-error: #b42318;
   --color-warning: #ffc107;
-  --color-success: #28a745;
+  --color-success: #176b35;
   --color-bg: #fff;
   --color-bg-alt: #f8f9fa;
   --color-border: #dee2e6;
   --color-text: #212529;
-  --color-text-muted: #6c757d;
+  --color-text-muted: #565e64;
+  --color-focus: #005fcc;
   --shadow-dropdown: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
   --border-radius: 4px;
   --spacing-xs: 4px;
@@ -417,21 +418,32 @@
 }
 
 .form-section-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-sm) var(--spacing-md);
   background: var(--color-bg-alt);
-  cursor: pointer;
-  user-select: none;
 }
 
 .form-section-header h3 {
   margin: 0;
   font-size: 1em;
+}
+
+.form-section-toggle {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: inherit;
+  text-align: left;
+  cursor: pointer;
+  user-select: none;
+}
+
+.form-section-toggle:focus-visible {
+  outline-offset: -3px;
 }
 
 .form-section-header .toggle-icon {
@@ -503,21 +515,36 @@
 .form-field input:focus,
 .form-field textarea:focus,
 .form-field select:focus {
-  outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(69, 32, 140, 0.1);
 }
 
-.form-field.has-error input,
-.form-field.has-error textarea,
-.form-field.has-error select {
+.form-field input:focus-visible,
+.form-field textarea:focus-visible,
+.form-field select:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 2px var(--color-bg);
+}
+
+.form-field [aria-invalid="true"] {
   border-color: var(--color-error);
+}
+
+.validation-group-error {
+  outline: 2px solid var(--color-error);
+  outline-offset: 2px;
 }
 
 .form-field .field-error {
   color: var(--color-error);
   font-size: 0.85em;
   margin-top: var(--spacing-xs);
+}
+
+.field-error-list {
+  margin: 0;
+  padding-left: var(--spacing-lg);
 }
 
 .form-field.highlight,
@@ -637,18 +664,41 @@
 }
 
 .wizard-progress {
-  display: flex;
-  justify-content: space-between;
   margin-bottom: var(--spacing-lg);
   padding: 0 var(--spacing-md);
+  max-width: 100%;
+}
+
+.wizard-progress-list {
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.wizard-progress-item {
+  display: flex;
+  flex: 1;
 }
 
 .wizard-step {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
   flex: 1;
   position: relative;
+}
+
+.wizard-step:not(button) {
+  cursor: default;
 }
 
 .wizard-step::after {
@@ -662,7 +712,7 @@
   z-index: 0;
 }
 
-.wizard-step:last-child::after {
+.wizard-progress-item:last-child .wizard-step::after {
   display: none;
 }
 
@@ -750,7 +800,6 @@
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--color-bg-alt);
   border-bottom: 1px solid var(--color-border);
-  flex-wrap: wrap;
   gap: var(--spacing-sm);
 }
 
@@ -763,7 +812,6 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  flex-wrap: wrap;
 }
 
 .preview-controls label {
@@ -812,7 +860,56 @@
   color: var(--color-error);
 }
 
+.error-link,
+.error-text {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  appearance: none;
+  border: 0;
+  padding: var(--spacing-xs);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  overflow-wrap: anywhere;
+}
+
+.error-link {
+  cursor: pointer;
+}
+
+.error-link:hover {
+  text-decoration: underline;
+}
+
+.editor-container :where(
+  button,
+  input,
+  select,
+  textarea,
+  summary,
+  [role="button"],
+  [tabindex]
+):focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 2px var(--color-bg);
+}
+
 /* Utility Classes */
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 .hidden {
   display: none !important;
 }
@@ -879,5 +976,39 @@
   to {
     transform: translateY(0);
     opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editor-container *,
+  .editor-container *::before,
+  .editor-container *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+  }
+
+  .form-field.highlight,
+  .form-section.highlight,
+  .wizard-field.highlight,
+  .loading::after,
+  .toast {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .editor-container :where(
+    button,
+    input,
+    select,
+    textarea,
+    summary,
+    [role="button"],
+    [tabindex]
+  ):focus-visible {
+    outline: 3px solid Highlight !important;
+    outline-offset: 3px;
   }
 }

--- a/docs/editor/css/editor.css
+++ b/docs/editor/css/editor.css
@@ -897,6 +897,10 @@
   box-shadow: 0 0 0 2px var(--color-bg);
 }
 
+.editor-container .form-section-toggle:focus-visible {
+  outline-offset: -3px;
+}
+
 /* Utility Classes */
 .visually-hidden {
   position: absolute !important;

--- a/docs/editor/css/editor.css
+++ b/docs/editor/css/editor.css
@@ -47,6 +47,7 @@
   width: 100%;
   margin: 0 auto;
   padding: var(--spacing-md);
+  box-sizing: border-box;
 }
 
 /* Configuration Panel */
@@ -113,6 +114,14 @@
 .mode-btn.active {
   background: var(--color-primary);
   color: var(--color-bg);
+}
+
+.mode-btn:focus-visible,
+.btn:focus-visible,
+.config-panel summary:focus-visible,
+.drop-zone:focus-within {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 3px;
 }
 
 /* Buttons */
@@ -394,6 +403,10 @@
   gap: var(--spacing-lg);
 }
 
+.editor-main > * {
+  min-width: 0;
+}
+
 @media (max-width: 1024px) {
   .editor-main {
     grid-template-columns: 1fr;
@@ -403,6 +416,59 @@
     order: -1;
   }
 }
+
+  @media (max-width: 768px) {
+    .editor-container {
+      padding: var(--spacing-sm);
+    }
+
+    .mode-selector {
+      width: 100%;
+    }
+
+    .mode-btn {
+      flex: 1 1 0;
+      padding-inline: var(--spacing-sm);
+    }
+
+    .url-input-row,
+    .wizard-nav {
+      flex-direction: column;
+    }
+
+    .url-input-row .btn,
+    .wizard-nav .btn {
+      width: 100%;
+    }
+
+    .validation-status {
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+
+    .last-validated {
+      flex-basis: 100%;
+      margin-left: calc(1.2em + var(--spacing-sm));
+    }
+
+    .preview-header,
+    .array-field-header {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: var(--spacing-sm);
+    }
+
+    .preview-controls {
+      width: 100%;
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--spacing-sm);
+    }
+
+    .preview-controls .btn {
+      flex: 1 1 auto;
+    }
+  }
 
 /* Form Editor */
 .form-editor {

--- a/docs/editor/css/editor.css
+++ b/docs/editor/css/editor.css
@@ -43,6 +43,7 @@
 
 /* Editor Container */
 .editor-container {
+  box-sizing: border-box;
   max-width: 100%;
   width: 100%;
   margin: 0 auto;
@@ -365,6 +366,7 @@
 /* Validation Status */
 .validation-status {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
@@ -372,6 +374,10 @@
   border-radius: var(--border-radius);
   margin-bottom: var(--spacing-md);
   font-size: 0.9em;
+}
+
+.validation-status > * {
+  min-width: 0;
 }
 
 .status-icon {
@@ -814,6 +820,18 @@
   color: var(--color-text-muted);
 }
 
+@media (max-width: 600px) {
+  .wizard-progress {
+    padding: 0;
+    overflow-x: auto;
+  }
+
+  .wizard-progress-list {
+    min-width: 34rem;
+    padding: 7px;
+  }
+}
+
 .wizard-step.active .wizard-step-label {
   color: var(--color-primary);
   font-weight: 600;
@@ -866,6 +884,7 @@
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--color-bg-alt);
   border-bottom: 1px solid var(--color-border);
+  flex-wrap: wrap;
   gap: var(--spacing-sm);
 }
 
@@ -878,6 +897,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
+  flex-wrap: wrap;
 }
 
 .preview-controls label {
@@ -900,6 +920,13 @@
   line-height: 1.5;
   white-space: pre-wrap;
   word-wrap: break-word;
+}
+
+@media (max-width: 1024px) {
+  .preview-panel {
+    position: static;
+    max-height: 60vh;
+  }
 }
 
 /* Error Panel */

--- a/docs/editor/index.html
+++ b/docs/editor/index.html
@@ -7,7 +7,7 @@ nav-title: Editor
 <div class="editor-container">
   <!-- Configuration Panel -->
   <div class="config-panel" id="config-panel">
-    <details>
+    <details aria-label="Editor configuration">
       <summary>Configuration</summary>
       <div class="config-content">
         <label for="schema-url">Schema URL (raw GitHub URL to schema.cue):</label>
@@ -21,9 +21,11 @@ nav-title: Editor
   </div>
 
   <!-- Mode Selector -->
-  <div class="mode-selector">
-    <button type="button" id="mode-form" class="mode-btn active">Form Editor</button>
-    <button type="button" id="mode-wizard" class="mode-btn">Wizard</button>
+  <div class="mode-selector" role="tablist" aria-label="Editor mode">
+    <button type="button" id="mode-form" class="mode-btn active" role="tab"
+      aria-selected="true" aria-controls="form-editor">Form Editor</button>
+    <button type="button" id="mode-wizard" class="mode-btn" role="tab"
+      aria-selected="false" aria-controls="wizard-editor" tabindex="-1">Wizard</button>
   </div>
 
   <!-- Input Section -->
@@ -53,7 +55,8 @@ nav-title: Editor
       <h3>Or Start Fresh</h3>
       <div class="single-maintainer-option">
         <label class="checkbox-label">
-          <input type="checkbox" id="single-maintainer-checkbox">
+          <input type="checkbox" id="single-maintainer-checkbox"
+            aria-controls="single-maintainer-fields" aria-expanded="false">
           <span>This is a single-maintainer project</span>
         </label>
         <p class="help-text">If checked, your contact info will be used for project administrator, repository core
@@ -95,25 +98,26 @@ nav-title: Editor
 
   <!-- Validation Status -->
   <div class="validation-status" id="validation-status">
-    <span class="status-icon" id="status-icon">●</span>
-    <span class="status-text" id="status-text">Ready</span>
+    <span class="status-icon" id="status-icon" aria-hidden="true">●</span>
+    <span class="status-text" id="status-text" role="status" aria-live="polite">Ready</span>
     <span class="last-validated" id="last-validated"></span>
   </div>
 
   <!-- Main Editor Area -->
   <div class="editor-main hidden" id="editor-main">
     <!-- Form Editor -->
-    <div class="form-editor" id="form-editor">
+    <div class="form-editor" id="form-editor" role="tabpanel" aria-labelledby="mode-form">
       <div class="form-sections" id="form-sections">
         <!-- Dynamically generated form sections will appear here -->
       </div>
     </div>
 
     <!-- Wizard Mode -->
-    <div class="wizard-editor hidden" id="wizard-editor">
-      <div class="wizard-progress" id="wizard-progress">
+    <div class="wizard-editor hidden" id="wizard-editor" role="tabpanel"
+      aria-labelledby="mode-wizard">
+      <nav class="wizard-progress" id="wizard-progress" aria-label="Wizard progress">
         <!-- Progress steps will be generated here -->
-      </div>
+      </nav>
       <div class="wizard-content" id="wizard-content">
         <!-- Wizard step content will appear here -->
       </div>
@@ -135,13 +139,15 @@ nav-title: Editor
           <button type="button" id="download-yaml-btn" class="btn btn-small btn-primary">Download</button>
         </div>
       </div>
-      <pre class="yaml-output" id="yaml-output"></pre>
+      <pre class="yaml-output" id="yaml-output" tabindex="0"
+        aria-label="Generated YAML preview"></pre>
     </div>
   </div>
 
   <!-- Error Panel -->
-  <div class="error-panel hidden" id="error-panel">
-    <h3>Validation Errors</h3>
+  <div class="error-panel hidden" id="error-panel" role="region"
+    aria-labelledby="validation-errors-heading">
+    <h3 id="validation-errors-heading">Validation Errors</h3>
     <ul class="error-list" id="error-list"></ul>
   </div>
 </div>
@@ -154,6 +160,7 @@ nav-title: Editor
 
 <!-- Application Scripts -->
 <script src="{{ '/editor/js/editor-utils.js' | relative_url }}"></script>
+<script src="{{ '/editor/js/validation-accessibility.js' | relative_url }}"></script>
 <script src="{{ '/editor/js/cue-parser.js' | relative_url }}"></script>
 <script src="{{ '/editor/js/schema-fallback.js' | relative_url }}"></script>
 <script src="{{ '/editor/js/form-builder.js' | relative_url }}"></script>

--- a/docs/editor/index.html
+++ b/docs/editor/index.html
@@ -139,7 +139,7 @@ nav-title: Editor
           <button type="button" id="download-yaml-btn" class="btn btn-small btn-primary">Download</button>
         </div>
       </div>
-      <pre class="yaml-output" id="yaml-output" tabindex="0"
+      <pre class="yaml-output" id="yaml-output" tabindex="0" role="region"
         aria-label="Generated YAML preview"></pre>
     </div>
   </div>

--- a/docs/editor/index.html
+++ b/docs/editor/index.html
@@ -118,6 +118,9 @@ nav-title: Editor
       <nav class="wizard-progress" id="wizard-progress" aria-label="Wizard progress">
         <!-- Progress steps will be generated here -->
       </nav>
+      <p id="wizard-progress-help" class="visually-hidden">
+        On narrow screens, use the left and right arrow keys to review all steps.
+      </p>
       <div class="wizard-content" id="wizard-content">
         <!-- Wizard step content will appear here -->
       </div>

--- a/docs/editor/js/app.js
+++ b/docs/editor/js/app.js
@@ -80,6 +80,9 @@ const App = (function () {
     elements.reloadSchemaBtn.addEventListener('click', loadSchema);
     elements.modeForm.addEventListener('click', () => setMode('form'));
     elements.modeWizard.addEventListener('click', () => setMode('wizard'));
+    [elements.modeForm, elements.modeWizard].forEach(element => {
+      element.addEventListener('keydown', handleModeKeydown);
+    });
     elements.browseBtn.addEventListener('click', () => elements.fileInput.click());
     elements.fileInput.addEventListener('change', handleFileSelect);
     elements.dropZone.addEventListener('dragover', handleDragOver);
@@ -238,9 +241,33 @@ const App = (function () {
     }
   }
 
+  function handleModeKeydown(event) {
+    const modes = ['form', 'wizard'];
+    let nextIndex = modes.indexOf(currentMode);
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      nextIndex = (nextIndex - 1 + modes.length) % modes.length;
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      nextIndex = (nextIndex + 1) % modes.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = modes.length - 1;
+    } else {
+      return;
+    }
+
+    event.preventDefault();
+    setMode(modes[nextIndex]);
+    (nextIndex === 0 ? elements.modeForm : elements.modeWizard).focus();
+  }
+
   function updateModeUI(rebuild = true) {
     elements.modeForm.classList.toggle('active', currentMode === 'form');
     elements.modeWizard.classList.toggle('active', currentMode === 'wizard');
+    elements.modeForm.setAttribute('aria-selected', String(currentMode === 'form'));
+    elements.modeWizard.setAttribute('aria-selected', String(currentMode === 'wizard'));
+    elements.modeForm.tabIndex = currentMode === 'form' ? 0 : -1;
+    elements.modeWizard.tabIndex = currentMode === 'wizard' ? 0 : -1;
     elements.formEditor.classList.toggle('hidden', currentMode !== 'form');
     elements.wizardEditor.classList.toggle('hidden', currentMode !== 'wizard');
     if (rebuild && state.dataLoaded) {
@@ -312,6 +339,7 @@ const App = (function () {
       Wizard.buildProgress(elements.wizardProgress);
       Wizard.buildContent(elements.wizardContent);
       updateWizardNav();
+      focusWizardHeading();
     }
     updatePreview();
   }
@@ -319,6 +347,7 @@ const App = (function () {
   function wizardPrev() {
     if (Wizard.prevStep()) {
       buildWizard();
+      focusWizardHeading();
     }
   }
 
@@ -332,6 +361,14 @@ const App = (function () {
       );
     } else if (Wizard.nextStep()) {
       buildWizard();
+      focusWizardHeading();
+    }
+  }
+
+  function focusWizardHeading() {
+    const heading = elements.wizardContent.querySelector('.wizard-step-heading');
+    if (heading) {
+      heading.focus();
     }
   }
 
@@ -675,9 +712,14 @@ const App = (function () {
     updateModeUI(true);
     updatePreview();
     runValidation();
+    (currentMode === 'form' ? elements.modeForm : elements.modeWizard).focus();
   }
 
   function handleSingleMaintainerToggle() {
+    elements.singleMaintainerCheckbox.setAttribute(
+      'aria-expanded',
+      String(elements.singleMaintainerCheckbox.checked)
+    );
     elements.singleMaintainerFields.classList.toggle(
       'hidden',
       !elements.singleMaintainerCheckbox.checked
@@ -742,7 +784,14 @@ const App = (function () {
       setStatus('valid', 'Valid');
       elements.errorPanel.classList.add('hidden');
     } else {
-      setStatus('invalid', `${errors.length} error(s)`);
+      const firstError = errors[0];
+      const firstErrorSummary = `${firstError.path || 'Root'}: ${firstError.message}`;
+      setStatus(
+        'invalid',
+        errors.length === 1
+          ? `1 validation error. ${firstErrorSummary}`
+          : `${errors.length} validation errors. First: ${firstErrorSummary}`
+      );
       showErrors(errors);
     }
     elements.lastValidated.textContent =
@@ -755,50 +804,100 @@ const App = (function () {
     elements.errorList.replaceChildren();
     errors.forEach(error => {
       const item = document.createElement('li');
+      const navigable = canNavigateToError(error.path);
+      const content = document.createElement(navigable ? 'button' : 'span');
+      if (navigable) {
+        content.type = 'button';
+        content.className = 'error-link';
+      } else {
+        content.className = 'error-text';
+      }
       const path = document.createElement('strong');
       path.textContent = `${error.path || 'Root'}:`;
-      item.appendChild(path);
-      item.appendChild(document.createTextNode(` ${error.message}`));
-      item.addEventListener('click', () => scrollToField(error.path));
-      item.style.cursor = 'pointer';
+      content.appendChild(path);
+      content.appendChild(document.createTextNode(` ${error.message}`));
+      if (navigable) {
+        content.addEventListener('click', () => scrollToField(error.path));
+      }
+      item.appendChild(content);
       elements.errorList.appendChild(item);
     });
     elements.errorPanel.classList.remove('hidden');
   }
 
+  function canNavigateToError(path) {
+    if (!path) {
+      return false;
+    }
+    const root = currentMode === 'form' ? elements.formEditor : elements.wizardEditor;
+    return Boolean(EditorUtils.findByDataPath(root, path))
+      || (currentMode === 'wizard' && Wizard.getStepIndexForPath(path) >= 0);
+  }
+
   function markFieldErrors(errors) {
     document.querySelectorAll('[data-path].has-error').forEach(element => {
       element.classList.remove('has-error');
-      const message = element.querySelector('[data-validation-error]');
+      const message = ValidationAccessibility.getOwnedMessage(element);
       if (message) {
+        ValidationAccessibility.clearTarget(element, message.id);
         message.remove();
       }
     });
 
-    errors.forEach(error => {
+    ValidationAccessibility.groupErrors(errors).forEach((group, groupIndex) => {
       const root = currentMode === 'form' ? elements.formEditor : elements.wizardEditor;
-      const field = EditorUtils.findByDataPath(root, error.path);
+      const field = EditorUtils.findByDataPath(root, group.path);
       if (!field) {
         return;
       }
       field.classList.add('has-error');
-      if (!field.querySelector('[data-validation-error]')) {
-        const message = document.createElement('div');
-        message.className = 'field-error';
-        message.dataset.validationError = 'true';
-        message.textContent = error.message;
-        field.appendChild(message);
+      const message = document.createElement('div');
+      message.className = 'field-error';
+      message.dataset.validationError = 'true';
+      message.id = `validation-error-${groupIndex}`;
+      if (group.messages.length === 1) {
+        message.textContent = group.messages[0];
+      } else {
+        const list = document.createElement('ul');
+        list.className = 'field-error-list';
+        group.messages.forEach(errorMessage => {
+          const item = document.createElement('li');
+          item.textContent = errorMessage;
+          list.appendChild(item);
+        });
+        message.appendChild(list);
       }
+      field.appendChild(message);
+
+      ValidationAccessibility.markTarget(field, message.id);
     });
   }
 
   function scrollToField(path) {
-    const root = currentMode === 'form' ? elements.formEditor : elements.wizardEditor;
-    const field = EditorUtils.findByDataPath(root, path);
+    let root = currentMode === 'form' ? elements.formEditor : elements.wizardEditor;
+    let field = EditorUtils.findByDataPath(root, path);
+    if (!field && currentMode === 'wizard') {
+      const stepIndex = Wizard.getStepIndexForPath(path);
+      if (stepIndex >= 0 && Wizard.goToStep(stepIndex)) {
+        buildWizard();
+        runValidation();
+        root = elements.wizardEditor;
+        field = EditorUtils.findByDataPath(root, path);
+      }
+    }
     if (!field) {
       return;
     }
-    field.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    const prefersReducedMotion = window.matchMedia
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    field.scrollIntoView({
+      behavior: ValidationAccessibility.getScrollBehavior(prefersReducedMotion),
+      block: 'center'
+    });
+    const target = ValidationAccessibility.prepareTarget(field);
+    if (target) {
+      target.element.focus({ preventScroll: true });
+    }
     field.classList.add('highlight');
     setTimeout(() => field.classList.remove('highlight'), 2000);
   }
@@ -817,7 +916,9 @@ const App = (function () {
     } else {
       elements.statusIcon.textContent = '●';
     }
-    elements.statusText.textContent = message;
+    if (elements.statusText.textContent !== message) {
+      elements.statusText.textContent = message;
+    }
   }
 
   async function copyYaml() {
@@ -836,6 +937,7 @@ const App = (function () {
   function showToast(message, type = 'info') {
     const toast = document.createElement('div');
     toast.className = `toast ${type}`;
+    toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
     toast.textContent = message;
     document.body.appendChild(toast);
     setTimeout(() => toast.remove(), 3000);

--- a/docs/editor/js/app.js
+++ b/docs/editor/js/app.js
@@ -13,6 +13,7 @@ const App = (function () {
   let lastValidation = null;
   let renderedErrorsSignature = null;
   let schemaLoadId = 0;
+  let wizardProgressObserver = null;
   let elements = {};
 
   const state = {
@@ -84,6 +85,11 @@ const App = (function () {
     [elements.modeForm, elements.modeWizard].forEach(element => {
       element.addEventListener('keydown', handleModeKeydown);
     });
+    window.addEventListener('resize', updateWizardProgressAccessibility);
+    if (typeof ResizeObserver === 'function') {
+      wizardProgressObserver = new ResizeObserver(updateWizardProgressAccessibility);
+      wizardProgressObserver.observe(elements.wizardProgress);
+    }
     elements.browseBtn.addEventListener('click', () => elements.fileInput.click());
     elements.fileInput.addEventListener('change', handleFileSelect);
     elements.dropZone.addEventListener('dragover', handleDragOver);
@@ -301,6 +307,7 @@ const App = (function () {
     FormBuilder.setReadOnlyPaths(state.readOnlyPaths);
     Wizard.setFormData(state.displayData);
     Wizard.buildProgress(elements.wizardProgress);
+    updateWizardProgressAccessibility();
     Wizard.buildContent(elements.wizardContent);
     updateWizardNav();
   }
@@ -338,6 +345,7 @@ const App = (function () {
     synchronizeEditedData(data);
     if (action === 'navigate') {
       Wizard.buildProgress(elements.wizardProgress);
+      updateWizardProgressAccessibility();
       Wizard.buildContent(elements.wizardContent);
       updateWizardNav();
       focusWizardHeading();
@@ -371,6 +379,18 @@ const App = (function () {
     const heading = elements.wizardContent.querySelector('.wizard-step-heading');
     if (heading) {
       heading.focus();
+    }
+  }
+
+  function updateWizardProgressAccessibility() {
+    const progress = elements.wizardProgress;
+    const scrollable = progress.scrollWidth > progress.clientWidth + 1;
+    if (scrollable) {
+      progress.tabIndex = 0;
+      progress.setAttribute('aria-describedby', 'wizard-progress-help');
+    } else {
+      progress.removeAttribute('tabindex');
+      progress.removeAttribute('aria-describedby');
     }
   }
 

--- a/docs/editor/js/app.js
+++ b/docs/editor/js/app.js
@@ -11,6 +11,7 @@ const App = (function () {
   let currentMode = 'form';
   let validationInterval = null;
   let lastValidation = null;
+  let renderedErrorsSignature = null;
   let schemaLoadId = 0;
   let elements = {};
 
@@ -355,6 +356,7 @@ const App = (function () {
     const isLastStep = Wizard.getCurrentStep() === Wizard.getTotalSteps() - 1;
     if (isLastStep) {
       setMode('form');
+      elements.modeForm.focus();
       showToast(
         'Wizard completed. You can make final edits and download the file.',
         'success'
@@ -801,6 +803,15 @@ const App = (function () {
   }
 
   function showErrors(errors) {
+    const signature = ValidationAccessibility.getErrorListSignature(
+      currentMode,
+      errors
+    );
+    if (signature === renderedErrorsSignature) {
+      elements.errorPanel.classList.remove('hidden');
+      return;
+    }
+    renderedErrorsSignature = signature;
     elements.errorList.replaceChildren();
     errors.forEach(error => {
       const item = document.createElement('li');
@@ -886,6 +897,9 @@ const App = (function () {
       }
     }
     if (!field) {
+      if (currentMode === 'wizard') {
+        focusWizardHeading();
+      }
       return;
     }
     const prefersReducedMotion = window.matchMedia

--- a/docs/editor/js/form-builder.js
+++ b/docs/editor/js/form-builder.js
@@ -58,7 +58,33 @@ const FormBuilder = (function () {
 
   function appendRequiredIndicator(label) {
     const indicator = createTextElement('span', 'required-indicator', '*');
+    indicator.setAttribute('aria-hidden', 'true');
     label.appendChild(indicator);
+  }
+
+  function toHtmlPattern(pattern) {
+    // HTML pattern expressions use the UnicodeSets (`v`) flag. A hyphen at the
+    // end of a character class must therefore be escaped even though the same
+    // schema expression is valid for JavaScript's traditional RegExp parser.
+    const candidate = String(pattern).replace(/(^|[^\\])-\]/g, '$1\\-]');
+    try {
+      // `v` is the mode required by the current HTML pattern specification.
+      // Browsers without UnicodeSets support still use the older `u` behavior.
+      new RegExp(candidate, 'v');
+      return candidate;
+    } catch (unicodeSetsError) {
+      try {
+        new RegExp('', 'v');
+        return null;
+      } catch (unsupportedFlagError) {
+        try {
+          new RegExp(candidate, 'u');
+          return candidate;
+        } catch (legacyPatternError) {
+          return null;
+        }
+      }
+    }
   }
 
   function appendDescription(container, description, className = 'field-description') {
@@ -107,31 +133,37 @@ const FormBuilder = (function () {
 
     const header = document.createElement('div');
     header.className = 'form-section-header';
-    header.setAttribute('role', 'button');
-    header.tabIndex = 0;
-    header.setAttribute('aria-expanded', 'true');
+    const contentId = generateId(`${path}-content`);
 
     const heading = document.createElement('h3');
-    heading.appendChild(createTextElement('span', 'toggle-icon', '▼'));
-    heading.appendChild(document.createTextNode(` ${toLabel(fieldName)} `));
+    heading.id = generateId(`${path}-heading`);
+    section.setAttribute('role', 'group');
+    section.setAttribute('aria-labelledby', heading.id);
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'form-section-toggle';
+    toggle.setAttribute('aria-expanded', 'true');
+    toggle.setAttribute('aria-controls', contentId);
+    toggle.appendChild(createTextElement('span', 'toggle-icon', '▼'));
+    toggle.querySelector('.toggle-icon').setAttribute('aria-hidden', 'true');
+    toggle.appendChild(document.createTextNode(` ${toLabel(fieldName)} `));
     if (!field.optional) {
-      heading.appendChild(createTextElement('span', 'form-section-required', '*'));
+      const indicator = createTextElement('span', 'form-section-required', '*');
+      indicator.setAttribute('aria-hidden', 'true');
+      toggle.appendChild(indicator);
     }
+    heading.appendChild(toggle);
     header.appendChild(heading);
     const toggleSection = () => {
       const collapsed = section.classList.toggle('collapsed');
-      header.setAttribute('aria-expanded', String(!collapsed));
+      toggle.setAttribute('aria-expanded', String(!collapsed));
     };
-    header.addEventListener('click', toggleSection);
-    header.addEventListener('keydown', event => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        toggleSection();
-      }
-    });
+    toggle.addEventListener('click', toggleSection);
 
     const content = document.createElement('div');
     content.className = 'form-section-content';
+    content.id = contentId;
     appendDescription(content, field.description);
 
     if (isReadOnly(path)) {
@@ -259,7 +291,10 @@ const FormBuilder = (function () {
     input.required = required;
     input.disabled = fieldReadOnly;
     if (pattern) {
-      input.pattern = pattern;
+      const htmlPattern = toHtmlPattern(pattern);
+      if (htmlPattern) {
+        input.pattern = htmlPattern;
+      }
     }
 
     input.addEventListener('input', () => {
@@ -331,6 +366,9 @@ const FormBuilder = (function () {
     const header = document.createElement('div');
     header.className = 'array-field-header';
     const heading = document.createElement('h4');
+    heading.id = generateId(`${path}-heading`);
+    container.setAttribute('role', 'group');
+    container.setAttribute('aria-labelledby', heading.id);
     heading.appendChild(document.createTextNode(`${toLabel(fieldName)} `));
     if (required) {
       appendRequiredIndicator(heading);
@@ -418,6 +456,11 @@ const FormBuilder = (function () {
     const container = document.createElement('div');
     container.className = 'array-item';
     container.dataset.path = path;
+    container.setAttribute('role', 'group');
+    container.setAttribute(
+      'aria-label',
+      `${toLabel(arrayPath.split('.').pop())} item ${index + 1}`
+    );
 
     const content = document.createElement('div');
     content.className = 'array-item-content';
@@ -444,6 +487,12 @@ const FormBuilder = (function () {
     removeButton.title = totalItems <= minItems
       ? `Minimum ${minItems} items required`
       : 'Remove';
+    removeButton.setAttribute(
+      'aria-label',
+      totalItems <= minItems
+        ? `Cannot remove item ${index + 1}; at least ${minItems} ${minItems === 1 ? 'item is' : 'items are'} required`
+        : `Remove ${toLabel(arrayPath.split('.').pop())} item ${index + 1}`
+    );
     removeButton.addEventListener('click', () => {
       const items = Utils.getNestedValue(formData, arrayPath);
       if (!Array.isArray(items)) {
@@ -466,7 +515,11 @@ const FormBuilder = (function () {
     container.className = 'form-field nested-object';
     container.dataset.path = path;
 
-    container.appendChild(buildFieldLabel(fieldName, null, !field.optional));
+    const label = buildFieldLabel(fieldName, null, !field.optional);
+    label.id = generateId(`${path}-label`);
+    container.setAttribute('role', 'group');
+    container.setAttribute('aria-labelledby', label.id);
+    container.appendChild(label);
     appendDescription(container, field.description);
 
     const fieldsContainer = document.createElement('div');
@@ -582,6 +635,7 @@ const FormBuilder = (function () {
     buildField,
     clearForm,
     getDefaultForType,
+    toHtmlPattern,
     toLabel
   };
 })();

--- a/docs/editor/js/form-builder.js
+++ b/docs/editor/js/form-builder.js
@@ -63,10 +63,14 @@ const FormBuilder = (function () {
   }
 
   function toHtmlPattern(pattern) {
+    const source = String(pattern);
+    if (source.includes('[[:')) {
+      return null;
+    }
     // HTML pattern expressions use the UnicodeSets (`v`) flag. A hyphen at the
     // end of a character class must therefore be escaped even though the same
     // schema expression is valid for JavaScript's traditional RegExp parser.
-    const candidate = String(pattern).replace(/(^|[^\\])-\]/g, '$1\\-]');
+    const candidate = source.replace(/(^|[^\\])-\]/g, '$1\\-]');
     try {
       // `v` is the mode required by the current HTML pattern specification.
       // Browsers without UnicodeSets support still use the older `u` behavior.
@@ -91,6 +95,14 @@ const FormBuilder = (function () {
     if (description) {
       container.appendChild(createTextElement('p', className, description));
     }
+  }
+
+  function getRemovalFocusIndex(removedIndex, enabledStates = []) {
+    if (enabledStates.length === 0) {
+      return -1;
+    }
+    const nextIndex = Math.min(removedIndex, enabledStates.length - 1);
+    return enabledStates[nextIndex] ? nextIndex : -1;
   }
 
   function resolveType(typeDef) {
@@ -416,7 +428,8 @@ const FormBuilder = (function () {
             items.length,
             minItems,
             path,
-            renderItems
+            renderItems,
+            focusAfterRemove
           )
         );
       });
@@ -424,6 +437,21 @@ const FormBuilder = (function () {
       addButton.textContent = invalidArray ? 'Replace with list' : '+ Add';
       addButton.disabled = isReadOnly(path)
         || (Number.isInteger(maxItems) && items.length >= maxItems);
+    }
+
+    function focusAfterRemove(index) {
+      const removeButtons = itemsContainer.querySelectorAll(
+        ':scope > .array-item > .array-item-controls button'
+      );
+      const focusIndex = getRemovalFocusIndex(
+        index,
+        Array.from(removeButtons, button => !button.disabled)
+      );
+      if (focusIndex >= 0) {
+        removeButtons[focusIndex].focus();
+      } else {
+        addButton.focus();
+      }
     }
 
     addButton.addEventListener('click', () => {
@@ -451,7 +479,8 @@ const FormBuilder = (function () {
     totalItems,
     minItems,
     arrayPath,
-    renderItems
+    renderItems,
+    focusAfterRemove
   ) {
     const container = document.createElement('div');
     container.className = 'array-item';
@@ -502,6 +531,7 @@ const FormBuilder = (function () {
       items.splice(index, 1);
       renderItems();
       triggerChange();
+      focusAfterRemove(index);
     });
 
     controls.appendChild(removeButton);
@@ -635,6 +665,7 @@ const FormBuilder = (function () {
     buildField,
     clearForm,
     getDefaultForType,
+    getRemovalFocusIndex,
     toHtmlPattern,
     toLabel
   };

--- a/docs/editor/js/validation-accessibility.js
+++ b/docs/editor/js/validation-accessibility.js
@@ -1,0 +1,164 @@
+/**
+ * Accessible validation helpers shared by the form and wizard renderers.
+ */
+const ValidationAccessibility = (function () {
+  'use strict';
+
+  const DIRECT_CONTROL_SELECTOR =
+    ':scope > input, :scope > textarea, :scope > select';
+  const ARRAY_ACTION_SELECTOR = ':scope > .array-field-header button';
+  const OWNED_MESSAGE_SELECTOR = ':scope > [data-validation-error]';
+
+  function groupErrors(errors = []) {
+    const groups = new Map();
+    for (const error of errors) {
+      const path = error.path || '';
+      if (!groups.has(path)) {
+        groups.set(path, []);
+      }
+      groups.get(path).push(error.message);
+    }
+    return Array.from(groups, ([path, messages]) => ({ path, messages }));
+  }
+
+  function getOwnedMessage(field) {
+    return field && typeof field.querySelector === 'function'
+      ? field.querySelector(OWNED_MESSAGE_SELECTOR)
+      : null;
+  }
+
+  function toGroupLabel(path) {
+    const words = String(path || 'document')
+      .replace(/\[\d+\]/g, ' ')
+      .replace(/[._-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return `${words || 'document'} validation group`;
+  }
+
+  function prepareTarget(field) {
+    if (!field || typeof field.querySelector !== 'function') {
+      return null;
+    }
+
+    const directControl = field.querySelector(DIRECT_CONTROL_SELECTOR);
+    if (directControl) {
+      return { element: directControl, supportsInvalid: true };
+    }
+
+    const arrayAction = field.querySelector(ARRAY_ACTION_SELECTOR);
+    if (arrayAction) {
+      return { element: arrayAction, supportsInvalid: false };
+    }
+
+    if (!field.hasAttribute('role')) {
+      field.setAttribute('role', 'group');
+      field.dataset.validationInjectedRole = 'true';
+    }
+    if (!field.hasAttribute('aria-label') && !field.hasAttribute('aria-labelledby')) {
+      field.setAttribute('aria-label', toGroupLabel(field.dataset.path));
+      field.dataset.validationInjectedLabel = 'true';
+    }
+    if (!field.hasAttribute('tabindex')) {
+      field.tabIndex = -1;
+      field.dataset.validationInjectedFocus = 'true';
+    }
+    return { element: field, supportsInvalid: false };
+  }
+
+  function addDescribedBy(element, id) {
+    const ids = new Set((element.getAttribute('aria-describedby') || '').split(/\s+/));
+    ids.delete('');
+    ids.add(id);
+    element.setAttribute('aria-describedby', Array.from(ids).join(' '));
+  }
+
+  function removeDescribedBy(element, id) {
+    const ids = (element.getAttribute('aria-describedby') || '')
+      .split(/\s+/)
+      .filter(value => value && value !== id);
+    if (ids.length > 0) {
+      element.setAttribute('aria-describedby', ids.join(' '));
+    } else {
+      element.removeAttribute('aria-describedby');
+    }
+  }
+
+  function markTarget(field, messageId) {
+    const target = prepareTarget(field);
+    if (!target) {
+      return null;
+    }
+    if (target.supportsInvalid) {
+      if (!target.element.dataset.validationOwnsInvalid) {
+        target.element.dataset.validationOwnsInvalid = 'true';
+        target.element.dataset.validationHadInvalid = String(
+          target.element.hasAttribute('aria-invalid')
+        );
+        if (target.element.hasAttribute('aria-invalid')) {
+          target.element.dataset.validationOriginalInvalid =
+            target.element.getAttribute('aria-invalid');
+        }
+      }
+      target.element.setAttribute('aria-invalid', 'true');
+    } else if (target.element === field) {
+      field.classList.add('validation-group-error');
+    }
+    addDescribedBy(target.element, messageId);
+    return target.element;
+  }
+
+  function clearTarget(field, messageId) {
+    const target = prepareTarget(field);
+    if (!target) {
+      return;
+    }
+    if (target.element.dataset.validationOwnsInvalid === 'true') {
+      if (target.element.dataset.validationHadInvalid === 'true') {
+        target.element.setAttribute(
+          'aria-invalid',
+          target.element.dataset.validationOriginalInvalid
+        );
+      } else {
+        target.element.removeAttribute('aria-invalid');
+      }
+      delete target.element.dataset.validationOwnsInvalid;
+      delete target.element.dataset.validationHadInvalid;
+      delete target.element.dataset.validationOriginalInvalid;
+    }
+    removeDescribedBy(target.element, messageId);
+
+    if (target.element === field) {
+      field.classList.remove('validation-group-error');
+      if (field.dataset.validationInjectedRole === 'true') {
+        field.removeAttribute('role');
+        delete field.dataset.validationInjectedRole;
+      }
+      if (field.dataset.validationInjectedLabel === 'true') {
+        field.removeAttribute('aria-label');
+        delete field.dataset.validationInjectedLabel;
+      }
+      if (field.dataset.validationInjectedFocus === 'true') {
+        field.removeAttribute('tabindex');
+        delete field.dataset.validationInjectedFocus;
+      }
+    }
+  }
+
+  function getScrollBehavior(prefersReducedMotion) {
+    return prefersReducedMotion ? 'auto' : 'smooth';
+  }
+
+  return {
+    groupErrors,
+    getOwnedMessage,
+    prepareTarget,
+    markTarget,
+    clearTarget,
+    getScrollBehavior
+  };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = ValidationAccessibility;
+}

--- a/docs/editor/js/validation-accessibility.js
+++ b/docs/editor/js/validation-accessibility.js
@@ -21,6 +21,13 @@ const ValidationAccessibility = (function () {
     return Array.from(groups, ([path, messages]) => ({ path, messages }));
   }
 
+  function getErrorListSignature(mode, errors = []) {
+    return JSON.stringify([
+      mode,
+      ...errors.map(error => [error.path || '', error.message])
+    ]);
+  }
+
   function getOwnedMessage(field) {
     return field && typeof field.querySelector === 'function'
       ? field.querySelector(OWNED_MESSAGE_SELECTOR)
@@ -29,7 +36,7 @@ const ValidationAccessibility = (function () {
 
   function toGroupLabel(path) {
     const words = String(path || 'document')
-      .replace(/\[\d+\]/g, ' ')
+      .replace(/\[(\d+)\]/g, (_, index) => ` item ${Number(index) + 1} `)
       .replace(/[._-]+/g, ' ')
       .replace(/\s+/g, ' ')
       .trim();
@@ -101,7 +108,7 @@ const ValidationAccessibility = (function () {
         }
       }
       target.element.setAttribute('aria-invalid', 'true');
-    } else if (target.element === field) {
+    } else {
       field.classList.add('validation-group-error');
     }
     addDescribedBy(target.element, messageId);
@@ -128,8 +135,11 @@ const ValidationAccessibility = (function () {
     }
     removeDescribedBy(target.element, messageId);
 
-    if (target.element === field) {
+    if (!target.supportsInvalid) {
       field.classList.remove('validation-group-error');
+    }
+
+    if (target.element === field) {
       if (field.dataset.validationInjectedRole === 'true') {
         field.removeAttribute('role');
         delete field.dataset.validationInjectedRole;
@@ -151,6 +161,7 @@ const ValidationAccessibility = (function () {
 
   return {
     groupErrors,
+    getErrorListSignature,
     getOwnedMessage,
     prepareTarget,
     markTarget,

--- a/docs/editor/js/wizard.js
+++ b/docs/editor/js/wizard.js
@@ -118,39 +118,74 @@ const Wizard = (function () {
     return currentStep > 0;
   }
 
+  function getStepIndexForPath(path) {
+    if (typeof path !== 'string' || path.length === 0) {
+      return -1;
+    }
+    return steps.findIndex(step => step.fields.some(fieldPath => {
+      return path === fieldPath
+        || path.startsWith(`${fieldPath}.`)
+        || path.startsWith(`${fieldPath}[`)
+        || fieldPath.startsWith(`${path}.`)
+        || fieldPath.startsWith(`${path}[`);
+    }));
+  }
+
   function buildProgress(container) {
     container.replaceChildren();
 
+    const list = document.createElement('ol');
+    list.className = 'wizard-progress-list';
+
     steps.forEach((step, index) => {
-      const stepElement = document.createElement('div');
+      const item = document.createElement('li');
+      item.className = 'wizard-progress-item';
+      const stepElement = document.createElement(index < currentStep ? 'button' : 'span');
+      if (index < currentStep) {
+        stepElement.type = 'button';
+      }
       stepElement.className = 'wizard-step';
+      const status = index < currentStep ? 'completed' : 'upcoming';
       if (index === currentStep) {
         stepElement.classList.add('active');
+        item.setAttribute('aria-current', 'step');
       } else if (index < currentStep) {
         stepElement.classList.add('completed');
       }
 
       const number = document.createElement('div');
       number.className = 'wizard-step-number';
+      number.setAttribute('aria-hidden', 'true');
       number.textContent = index < currentStep ? '✓' : String(index + 1);
 
       const label = document.createElement('div');
       label.className = 'wizard-step-label';
+      label.setAttribute('aria-hidden', 'true');
       label.textContent = step.title;
 
+      const accessibleText = document.createElement('span');
+      accessibleText.className = 'visually-hidden';
+      accessibleText.textContent = index === currentStep
+        ? `Step ${index + 1}: ${step.title}`
+        : `Step ${index + 1}: ${step.title}, ${status}`;
+
+      stepElement.appendChild(accessibleText);
       stepElement.appendChild(number);
       stepElement.appendChild(label);
-      stepElement.addEventListener('click', () => {
-        if (index <= currentStep) {
+      if (index < currentStep) {
+        stepElement.addEventListener('click', () => {
           goToStep(index);
           if (onChangeCallback) {
             onChangeCallback(formData, 'navigate');
           }
-        }
-      });
+        });
+      }
 
-      container.appendChild(stepElement);
+      item.appendChild(stepElement);
+      list.appendChild(item);
     });
+
+    container.appendChild(list);
   }
 
   function buildContent(container) {
@@ -165,6 +200,8 @@ const Wizard = (function () {
     header.className = 'wizard-step-header';
 
     const heading = document.createElement('h3');
+    heading.className = 'wizard-step-heading';
+    heading.tabIndex = -1;
     heading.textContent = step.title;
     const description = document.createElement('p');
     description.className = 'help-text';
@@ -227,6 +264,9 @@ const Wizard = (function () {
       const fieldHeader = document.createElement('div');
       fieldHeader.className = 'wizard-field-header';
       const heading = document.createElement('h4');
+      heading.id = `wizard-group-${path.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+      container.setAttribute('role', 'group');
+      container.setAttribute('aria-labelledby', heading.id);
       heading.textContent = FormBuilder.toLabel(fieldName);
       fieldHeader.appendChild(heading);
       if (field.description) {
@@ -299,6 +339,7 @@ const Wizard = (function () {
     prevStep,
     canGoNext,
     canGoPrev,
+    getStepIndexForPath,
     buildProgress,
     buildContent,
     steps

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,24 @@
     "": {
       "name": "security-insights-editor-tests",
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "js-yaml": "4.3.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/argparse": {
@@ -15,6 +32,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
@@ -37,6 +69,38 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "security-insights-editor-tests",
   "private": true,
   "scripts": {
-    "test": "node --test tests/editor/*.test.js"
+    "test": "node --test tests/editor/*.test.js",
+    "test:browser": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "js-yaml": "4.3.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,16 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/browser',
+  timeout: 30_000,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    browserName: 'chromium'
+  },
+  webServer: {
+    command: 'cd docs && bundle exec jekyll build --source . --destination /tmp/security-insights-site && python3 -m http.server 4173 --bind 127.0.0.1 --directory /tmp/security-insights-site',
+    url: 'http://127.0.0.1:4173/editor/',
+    reuseExistingServer: false,
+    timeout: 300_000
+  }
+});

--- a/tests/browser/editor.spec.js
+++ b/tests/browser/editor.spec.js
@@ -1,0 +1,87 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const schemaSource = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'spec', 'schema.cue'),
+  'utf8'
+);
+const yamlSource = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'node_modules', 'js-yaml', 'dist', 'js-yaml.min.js'),
+  'utf8'
+);
+const exampleSource = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'examples', 'example-full.yml'),
+  'utf8'
+);
+
+test.beforeEach(async ({ page }) => {
+  await page.route('https://raw.githubusercontent.com/**', route =>
+    route.fulfill({ status: 200, contentType: 'text/plain', body: schemaSource })
+  );
+  await page.route('https://cdn.jsdelivr.net/**', route =>
+    route.fulfill({ status: 200, contentType: 'application/javascript', body: yamlSource })
+  );
+});
+
+test('keyboard users can move through the editor workflow', async ({ page }) => {
+  await page.goto('/editor/');
+  await expect(page.locator('#status-text')).toHaveText('Schema loaded');
+
+  await page.getByRole('button', { name: 'Start Fresh' }).click();
+  await page.getByRole('tab', { name: 'Wizard' }).click();
+  await expect(page.locator('#wizard-editor')).toBeVisible();
+  await expect(page.locator('.wizard-step-heading')).toHaveText('Header');
+
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.locator('.wizard-step-heading')).toHaveText('Project');
+
+  await page.getByRole('tab', { name: 'Form Editor' }).click();
+  await page.getByRole('tab', { name: 'Form Editor' }).focus();
+  await page.keyboard.press('ArrowRight');
+  await expect(page.getByRole('tab', { name: 'Wizard' })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+});
+
+test('malformed pasted YAML is reported without opening the editor', async ({ page }) => {
+  await page.goto('/editor/');
+  await expect(page.locator('#status-text')).toHaveText('Schema loaded');
+
+  await page.locator('#yaml-paste').fill('header: [');
+  await page.getByRole('button', { name: 'Load from Paste' }).click();
+  await expect(page.locator('#status-text')).toContainText('Error:');
+  await expect(page.locator('#editor-main')).toHaveClass(/hidden/);
+});
+
+test('valid YAML can be imported, edited, and downloaded', async ({ page }) => {
+  await page.goto('/editor/');
+  await expect(page.locator('#status-text')).toHaveText('Schema loaded');
+
+  await page.locator('#yaml-paste').fill(exampleSource);
+  await page.getByRole('button', { name: 'Load from Paste' }).click();
+  await expect(page.locator('#editor-main')).toBeVisible();
+  await expect(page.locator('#status-text')).toHaveText('Valid');
+
+  const projectName = page.locator('[data-path="project.name"] input');
+  await expect(projectName).toBeVisible();
+  await projectName.fill('Updated Security Insights Project');
+
+  await expect(page.locator('#yaml-output')).toContainText(
+    'Updated Security Insights Project'
+  );
+  const download = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download' }).click();
+  const downloaded = await download;
+  expect(downloaded.suggestedFilename()).toBe('security-insights.yml');
+});
+
+test('navigation submenus open from the keyboard', async ({ page }) => {
+  await page.goto('/');
+  const dropdown = page.locator('.nav-dropdown').first();
+  await dropdown.locator('summary').focus();
+  await page.keyboard.press('Enter');
+  await expect(dropdown).toHaveAttribute('open', '');
+  await expect(dropdown.locator('a').first()).toBeVisible();
+});

--- a/tests/browser/editor.spec.js
+++ b/tests/browser/editor.spec.js
@@ -85,3 +85,22 @@ test('navigation submenus open from the keyboard', async ({ page }) => {
   await expect(dropdown).toHaveAttribute('open', '');
   await expect(dropdown.locator('a').first()).toBeVisible();
 });
+
+test('wizard progress remains reachable on narrow screens', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto('/editor/');
+  await expect(page.locator('#status-text')).toHaveText('Schema loaded');
+
+  await page.getByRole('button', { name: 'Start Fresh' }).click();
+  await page.getByRole('tab', { name: 'Wizard' }).click();
+
+  const progress = page.locator('#wizard-progress');
+  await expect(progress).toHaveAttribute('tabindex', '0');
+  await expect(progress).toHaveAttribute(
+    'aria-describedby',
+    'wizard-progress-help'
+  );
+  expect(
+    await progress.evaluate(element => element.scrollWidth > element.clientWidth)
+  ).toBe(true);
+});

--- a/tests/editor/source-audit.test.js
+++ b/tests/editor/source-audit.test.js
@@ -55,6 +55,56 @@ test('editor source avoids user-data innerHTML and wires secure script loading',
   );
 });
 
+test('editor exposes keyboard navigation and validation semantics', () => {
+  const app = fs.readFileSync(path.join(root, 'docs/editor/js/app.js'), 'utf8');
+  const form = fs.readFileSync(
+    path.join(root, 'docs/editor/js/form-builder.js'),
+    'utf8'
+  );
+  const wizard = fs.readFileSync(
+    path.join(root, 'docs/editor/js/wizard.js'),
+    'utf8'
+  );
+  const page = fs.readFileSync(path.join(root, 'docs/editor/index.html'), 'utf8');
+  const styles = fs.readFileSync(
+    path.join(root, 'docs/editor/css/editor.css'),
+    'utf8'
+  );
+
+  assert.match(page, /class="mode-selector" role="tablist"/);
+  assert.match(page, /<details aria-label="Editor configuration">/);
+  assert.match(page, /id="mode-form"[^>]*role="tab"[^>]*aria-selected="true"/);
+  assert.match(page, /id="status-text" role="status" aria-live="polite"/);
+  assert.match(page, /id="wizard-progress" aria-label="Wizard progress"/);
+  assert.match(
+    page,
+    /id="yaml-output" tabindex="0"[\s\S]*aria-label="Generated YAML preview"/
+  );
+  assert.match(
+    page,
+    /id="error-panel" role="region"[\s\S]*aria-labelledby="validation-errors-heading"/
+  );
+  assert.match(app, /event\.key === 'ArrowRight'/);
+  assert.match(app, /setAttribute\('aria-selected'/);
+  assert.match(app, /ValidationAccessibility\.markTarget\(field, message\.id\)/);
+  assert.match(app, /ValidationAccessibility\.getOwnedMessage\(element\)/);
+  assert.match(app, /ValidationAccessibility\.getScrollBehavior\(prefersReducedMotion\)/);
+  assert.match(app, /toast\.setAttribute\('role', type === 'error' \? 'alert' : 'status'\)/);
+  assert.match(app, /target\.element\.focus\(\{ preventScroll: true \}\)/);
+  assert.match(app, /Wizard\.getStepIndexForPath\(path\)/);
+  assert.match(form, /toggle\.setAttribute\('aria-controls', contentId\)/);
+  assert.match(form, /toggle\.type = 'button'/);
+  assert.doesNotMatch(form, /setAttribute\('role', 'button'\)/);
+  assert.match(form, /container\.setAttribute\('aria-labelledby', heading\.id\)/);
+  assert.match(wizard, /className = 'wizard-progress-list'/);
+  assert.match(wizard, /setAttribute\('aria-current', 'step'\)/);
+  assert.match(styles, /:focus-visible/);
+  assert.match(
+    styles,
+    /\.wizard-progress-item:last-child \.wizard-step::after/
+  );
+});
+
 const cueAvailable = spawnSync('cue', ['version'], {
   cwd: root,
   encoding: 'utf8'

--- a/tests/editor/source-audit.test.js
+++ b/tests/editor/source-audit.test.js
@@ -78,7 +78,7 @@ test('editor exposes keyboard navigation and validation semantics', () => {
   assert.match(page, /id="wizard-progress" aria-label="Wizard progress"/);
   assert.match(
     page,
-    /id="yaml-output" tabindex="0"[\s\S]*aria-label="Generated YAML preview"/
+    /id="yaml-output" tabindex="0" role="region"[\s\S]*aria-label="Generated YAML preview"/
   );
   assert.match(
     page,
@@ -92,13 +92,23 @@ test('editor exposes keyboard navigation and validation semantics', () => {
   assert.match(app, /toast\.setAttribute\('role', type === 'error' \? 'alert' : 'status'\)/);
   assert.match(app, /target\.element\.focus\(\{ preventScroll: true \}\)/);
   assert.match(app, /Wizard\.getStepIndexForPath\(path\)/);
+  assert.match(app, /getErrorListSignature\(/);
+  assert.match(app, /signature === renderedErrorsSignature/);
+  assert.match(app, /setMode\('form'\);\s*elements\.modeForm\.focus\(\)/);
+  assert.match(app, /if \(currentMode === 'wizard'\) \{\s*focusWizardHeading\(\)/);
   assert.match(form, /toggle\.setAttribute\('aria-controls', contentId\)/);
   assert.match(form, /toggle\.type = 'button'/);
   assert.doesNotMatch(form, /setAttribute\('role', 'button'\)/);
   assert.match(form, /container\.setAttribute\('aria-labelledby', heading\.id\)/);
+  assert.match(form, /function focusAfterRemove\(index\)/);
+  assert.match(form, /triggerChange\(\);\s*focusAfterRemove\(index\);/);
   assert.match(wizard, /className = 'wizard-progress-list'/);
   assert.match(wizard, /setAttribute\('aria-current', 'step'\)/);
   assert.match(styles, /:focus-visible/);
+  assert.match(
+    styles,
+    /\.editor-container \.form-section-toggle:focus-visible\s*\{\s*outline-offset: -3px;/
+  );
   assert.match(
     styles,
     /\.wizard-progress-item:last-child \.wizard-step::after/

--- a/tests/editor/source-audit.test.js
+++ b/tests/editor/source-audit.test.js
@@ -113,6 +113,11 @@ test('editor exposes keyboard navigation and validation semantics', () => {
     styles,
     /\.wizard-progress-item:last-child \.wizard-step::after/
   );
+  assert.match(styles, /@media \(max-width: 600px\)[\s\S]*\.wizard-progress\s*\{/);
+  assert.match(styles, /\.wizard-progress-list\s*\{[\s\S]*min-width: 34rem/);
+  assert.match(styles, /@media \(max-width: 1024px\)[\s\S]*\.preview-panel\s*\{/);
+  assert.match(app, /progress\.scrollWidth > progress\.clientWidth \+ 1/);
+  assert.match(app, /wizard-progress-help/);
 });
 
 test('site navigation uses native keyboard-operable submenus', () => {

--- a/tests/editor/source-audit.test.js
+++ b/tests/editor/source-audit.test.js
@@ -115,6 +115,23 @@ test('editor exposes keyboard navigation and validation semantics', () => {
   );
 });
 
+test('site navigation uses native keyboard-operable submenus', () => {
+  const nav = fs.readFileSync(
+    path.join(root, 'docs/_includes/nav-items.html'),
+    'utf8'
+  );
+  const styles = fs.readFileSync(
+    path.join(root, 'docs/assets/css/style.scss'),
+    'utf8'
+  );
+
+  assert.match(nav, /<details class="nav-dropdown">/);
+  assert.match(nav, /<summary class="nav-item nav-dropdown-toggle">/);
+  assert.match(nav, /<\/summary>/);
+  assert.match(styles, /\.nav-dropdown\[open\] \.nav-dropdown-content/);
+  assert.match(styles, /@media screen and \(max-width: 600px\)/);
+});
+
 const cueAvailable = spawnSync('cue', ['version'], {
   cwd: root,
   encoding: 'utf8'

--- a/tests/editor/validation-accessibility.test.js
+++ b/tests/editor/validation-accessibility.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const ValidationAccessibility = require(
+  '../../docs/editor/js/validation-accessibility.js'
+);
+
+const DIRECT_SELECTOR = ':scope > input, :scope > textarea, :scope > select';
+const ARRAY_SELECTOR = ':scope > .array-field-header button';
+const MESSAGE_SELECTOR = ':scope > [data-validation-error]';
+
+class FakeElement {
+  constructor({ path = '', matches = {}, attributes = {} } = {}) {
+    this.dataset = path ? { path } : {};
+    this.matches = matches;
+    this.attributes = new Map(Object.entries(attributes));
+    this.classes = new Set();
+    this.classList = {
+      add: value => this.classes.add(value),
+      remove: value => this.classes.delete(value)
+    };
+  }
+
+  querySelector(selector) {
+    return this.matches[selector] || null;
+  }
+
+  hasAttribute(name) {
+    return this.attributes.has(name);
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+
+  set tabIndex(value) {
+    this.attributes.set('tabindex', String(value));
+  }
+}
+
+test('groups every validation message by its exact path in stable order', () => {
+  assert.deepEqual(ValidationAccessibility.groupErrors(), []);
+  assert.deepEqual(
+    ValidationAccessibility.groupErrors([
+      { path: 'project.name', message: 'is required' },
+      { path: 'header.url', message: 'must be a URL' },
+      { path: 'project.name', message: 'is too short' },
+      { message: 'document is invalid' }
+    ]),
+    [
+      { path: 'project.name', messages: ['is required', 'is too short'] },
+      { path: 'header.url', messages: ['must be a URL'] },
+      { path: '', messages: ['document is invalid'] }
+    ]
+  );
+});
+
+test('only returns a validation message owned directly by the field', () => {
+  const message = new FakeElement();
+  const field = new FakeElement({ matches: { [MESSAGE_SELECTOR]: message } });
+  assert.equal(ValidationAccessibility.getOwnedMessage(field), message);
+  assert.equal(ValidationAccessibility.getOwnedMessage(new FakeElement()), null);
+  assert.equal(ValidationAccessibility.getOwnedMessage(null), null);
+  assert.equal(ValidationAccessibility.getOwnedMessage({}), null);
+});
+
+test('direct value controls receive invalid state and preserve descriptions', () => {
+  const input = new FakeElement({ attributes: { 'aria-describedby': 'existing' } });
+  const field = new FakeElement({ matches: { [DIRECT_SELECTOR]: input } });
+
+  assert.deepEqual(
+    ValidationAccessibility.prepareTarget(field),
+    { element: input, supportsInvalid: true }
+  );
+  assert.equal(ValidationAccessibility.markTarget(field, 'error-1'), input);
+  assert.equal(input.getAttribute('aria-invalid'), 'true');
+  assert.equal(input.getAttribute('aria-describedby'), 'existing error-1');
+
+  ValidationAccessibility.markTarget(field, 'error-1');
+  assert.equal(input.getAttribute('aria-describedby'), 'existing error-1');
+  ValidationAccessibility.clearTarget(field, 'error-1');
+  assert.equal(input.getAttribute('aria-invalid'), null);
+  assert.equal(input.getAttribute('aria-describedby'), 'existing');
+});
+
+test('direct controls restore pre-existing invalid semantics', () => {
+  const input = new FakeElement({ attributes: { 'aria-invalid': 'grammar' } });
+  const field = new FakeElement({ matches: { [DIRECT_SELECTOR]: input } });
+
+  ValidationAccessibility.markTarget(field, 'error-1');
+  assert.equal(input.getAttribute('aria-invalid'), 'true');
+
+  ValidationAccessibility.clearTarget(field, 'error-1');
+  assert.equal(input.getAttribute('aria-invalid'), 'grammar');
+  assert.equal(input.dataset.validationOwnsInvalid, undefined);
+});
+
+test('array actions are described but never represented as invalid values', () => {
+  const button = new FakeElement();
+  const field = new FakeElement({ matches: { [ARRAY_SELECTOR]: button } });
+
+  assert.equal(ValidationAccessibility.markTarget(field, 'array-error'), button);
+  assert.equal(button.getAttribute('aria-invalid'), null);
+  assert.equal(button.getAttribute('aria-describedby'), 'array-error');
+  ValidationAccessibility.clearTarget(field, 'array-error');
+  assert.equal(button.getAttribute('aria-describedby'), null);
+
+  assert.doesNotThrow(() => ValidationAccessibility.clearTarget(field, 'missing-error'));
+});
+
+test('structural errors create and fully remove an accessible validation group', () => {
+  const field = new FakeElement({ path: 'project.repositories[0].core-team' });
+
+  assert.equal(ValidationAccessibility.markTarget(field, 'group-error'), field);
+  assert.equal(field.getAttribute('role'), 'group');
+  assert.equal(
+    field.getAttribute('aria-label'),
+    'project repositories core team validation group'
+  );
+  assert.equal(field.getAttribute('tabindex'), '-1');
+  assert.equal(field.getAttribute('aria-invalid'), null);
+  assert.equal(field.getAttribute('aria-describedby'), 'group-error');
+  assert.equal(field.classes.has('validation-group-error'), true);
+
+  ValidationAccessibility.clearTarget(field, 'group-error');
+  assert.equal(field.getAttribute('role'), null);
+  assert.equal(field.getAttribute('aria-label'), null);
+  assert.equal(field.getAttribute('tabindex'), null);
+  assert.equal(field.getAttribute('aria-invalid'), null);
+  assert.equal(field.getAttribute('aria-describedby'), null);
+  assert.equal(field.classes.has('validation-group-error'), false);
+  assert.deepEqual(field.dataset, { path: 'project.repositories[0].core-team' });
+});
+
+test('structural errors preserve author-provided group semantics', () => {
+  const field = new FakeElement({
+    attributes: {
+      role: 'group',
+      'aria-labelledby': 'group-heading',
+      tabindex: '0',
+      'aria-describedby': 'group-help'
+    }
+  });
+
+  ValidationAccessibility.markTarget(field, 'group-error');
+  assert.equal(field.getAttribute('aria-label'), null);
+  ValidationAccessibility.clearTarget(field, 'group-error');
+  assert.equal(field.getAttribute('role'), 'group');
+  assert.equal(field.getAttribute('aria-labelledby'), 'group-heading');
+  assert.equal(field.getAttribute('tabindex'), '0');
+  assert.equal(field.getAttribute('aria-describedby'), 'group-help');
+});
+
+test('structural errors preserve an author-provided accessible label', () => {
+  const field = new FakeElement({ attributes: { 'aria-label': 'Repository entries' } });
+  ValidationAccessibility.markTarget(field, 'group-error');
+  assert.equal(field.getAttribute('role'), 'group');
+  assert.equal(field.getAttribute('aria-label'), 'Repository entries');
+  ValidationAccessibility.clearTarget(field, 'group-error');
+  assert.equal(field.getAttribute('role'), null);
+  assert.equal(field.getAttribute('aria-label'), 'Repository entries');
+});
+
+test('structural fallback names an empty path as the document group', () => {
+  const field = new FakeElement();
+  ValidationAccessibility.prepareTarget(field);
+  assert.equal(field.getAttribute('aria-label'), 'document validation group');
+
+  const punctuationOnlyPath = new FakeElement({ path: '...' });
+  ValidationAccessibility.prepareTarget(punctuationOnlyPath);
+  assert.equal(
+    punctuationOnlyPath.getAttribute('aria-label'),
+    'document validation group'
+  );
+});
+
+test('invalid targets are handled safely', () => {
+  assert.equal(ValidationAccessibility.prepareTarget(null), null);
+  assert.equal(ValidationAccessibility.prepareTarget({}), null);
+  assert.equal(ValidationAccessibility.markTarget(null, 'error'), null);
+  assert.doesNotThrow(() => ValidationAccessibility.clearTarget(null, 'error'));
+});
+
+test('scroll behavior respects the reduced-motion preference', () => {
+  assert.equal(ValidationAccessibility.getScrollBehavior(true), 'auto');
+  assert.equal(ValidationAccessibility.getScrollBehavior(false), 'smooth');
+});

--- a/tests/editor/validation-accessibility.test.js
+++ b/tests/editor/validation-accessibility.test.js
@@ -64,6 +64,36 @@ test('groups every validation message by its exact path in stable order', () => 
   );
 });
 
+test('error-list signatures change only when mode or error content changes', () => {
+  const errors = [{ path: 'project.name', message: 'is required' }];
+  const signature = ValidationAccessibility.getErrorListSignature('form', errors);
+
+  assert.equal(
+    ValidationAccessibility.getErrorListSignature('form'),
+    JSON.stringify(['form'])
+  );
+  assert.equal(
+    ValidationAccessibility.getErrorListSignature('form', [
+      { message: 'document is invalid' }
+    ]),
+    JSON.stringify(['form', ['', 'document is invalid']])
+  );
+  assert.equal(
+    ValidationAccessibility.getErrorListSignature('form', [...errors]),
+    signature
+  );
+  assert.notEqual(
+    ValidationAccessibility.getErrorListSignature('wizard', errors),
+    signature
+  );
+  assert.notEqual(
+    ValidationAccessibility.getErrorListSignature('form', [
+      { path: 'project.name', message: 'is too short' }
+    ]),
+    signature
+  );
+});
+
 test('only returns a validation message owned directly by the field', () => {
   const message = new FakeElement();
   const field = new FakeElement({ matches: { [MESSAGE_SELECTOR]: message } });
@@ -111,8 +141,10 @@ test('array actions are described but never represented as invalid values', () =
   assert.equal(ValidationAccessibility.markTarget(field, 'array-error'), button);
   assert.equal(button.getAttribute('aria-invalid'), null);
   assert.equal(button.getAttribute('aria-describedby'), 'array-error');
+  assert.equal(field.classes.has('validation-group-error'), true);
   ValidationAccessibility.clearTarget(field, 'array-error');
   assert.equal(button.getAttribute('aria-describedby'), null);
+  assert.equal(field.classes.has('validation-group-error'), false);
 
   assert.doesNotThrow(() => ValidationAccessibility.clearTarget(field, 'missing-error'));
 });
@@ -124,7 +156,7 @@ test('structural errors create and fully remove an accessible validation group',
   assert.equal(field.getAttribute('role'), 'group');
   assert.equal(
     field.getAttribute('aria-label'),
-    'project repositories core team validation group'
+    'project repositories item 1 core team validation group'
   );
   assert.equal(field.getAttribute('tabindex'), '-1');
   assert.equal(field.getAttribute('aria-invalid'), null);

--- a/tests/editor/wizard-accessibility.test.js
+++ b/tests/editor/wizard-accessibility.test.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Wizard = require('../../docs/editor/js/wizard.js');
+const FormBuilder = require('../../docs/editor/js/form-builder.js');
+const SchemaFallback = require('../../docs/editor/js/schema-fallback.js');
+
+class FakeClassList {
+  constructor() {
+    this.values = new Set();
+  }
+
+  add(...values) {
+    values.forEach(value => this.values.add(value));
+  }
+
+  contains(value) {
+    return this.values.has(value);
+  }
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.attributes = new Map();
+    this.classList = new FakeClassList();
+    this.listeners = new Map();
+    this.disabled = false;
+    this.type = '';
+    this.textContent = '';
+  }
+
+  set className(value) {
+    this.classList = new FakeClassList();
+    value.split(/\s+/).filter(Boolean).forEach(name => this.classList.add(name));
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  get firstElementChild() {
+    return this.children[0] || null;
+  }
+
+  replaceChildren(...children) {
+    this.children = [...children];
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) || null;
+  }
+
+  addEventListener(type, callback) {
+    this.listeners.set(type, callback);
+  }
+
+  click() {
+    if (!this.disabled) {
+      this.listeners.get('click')?.();
+    }
+  }
+}
+
+test('schema regexes are translated for the HTML UnicodeSets pattern mode', () => {
+  assert.equal(
+    FormBuilder.toHtmlPattern('^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$'),
+    '^[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}$'
+  );
+  assert.equal(FormBuilder.toHtmlPattern('^[1-9]+$'), '^[1-9]+$');
+  assert.equal(FormBuilder.toHtmlPattern('['), null);
+});
+
+test('every bundled schema pattern is compatible with native HTML validation', () => {
+  const patterns = [];
+  const visit = value => {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+    if (typeof value.pattern === 'string') {
+      patterns.push(value.pattern);
+    }
+    Object.values(value).forEach(visit);
+  };
+  visit(SchemaFallback.types);
+
+  assert.ok(patterns.length > 0);
+  for (const pattern of patterns) {
+    assert.notEqual(
+      FormBuilder.toHtmlPattern(pattern),
+      null,
+      `HTML pattern is incompatible: ${pattern}`
+    );
+  }
+});
+
+test('wizard progress uses native buttons and exposes the current step', () => {
+  const previousDocument = global.document;
+  global.document = {
+    createElement: tagName => new FakeElement(tagName)
+  };
+
+  try {
+    const actions = [];
+    Wizard.init({}, (_data, action) => actions.push(action));
+    Wizard.goToStep(2);
+    const container = new FakeElement('div');
+
+    Wizard.buildProgress(container);
+
+    const list = container.firstElementChild;
+    const progressSteps = list.children.map(item => item.firstElementChild);
+    assert.equal(list.tagName, 'OL');
+    assert.equal(progressSteps.length, Wizard.getTotalSteps());
+    assert.deepEqual(
+      progressSteps.map(step => step.tagName),
+      ['BUTTON', 'BUTTON', 'SPAN', 'SPAN', 'SPAN', 'SPAN']
+    );
+    assert.equal(progressSteps[2].getAttribute('aria-current'), null);
+    assert.equal(list.children[2].getAttribute('aria-current'), 'step');
+    assert.deepEqual(
+      progressSteps.map(step => step.children[0].textContent),
+      Wizard.steps.map((step, index) => {
+        if (index === 2) {
+          return `Step ${index + 1}: ${step.title}`;
+        }
+        const status = index < 2 ? 'completed' : 'upcoming';
+        return `Step ${index + 1}: ${step.title}, ${status}`;
+      })
+    );
+    assert.equal(Wizard.getStepIndexForPath('header.url'), 0);
+    assert.equal(Wizard.getStepIndexForPath('project.name'), 1);
+    assert.equal(Wizard.getStepIndexForPath('repository.security.tools[0]'), 4);
+    assert.equal(Wizard.getStepIndexForPath('unknown.path'), -1);
+
+    progressSteps[0].click();
+    assert.equal(Wizard.getCurrentStep(), 0);
+    assert.deepEqual(actions, ['navigate']);
+
+    progressSteps[3].click();
+    assert.equal(Wizard.getCurrentStep(), 0);
+    assert.deepEqual(actions, ['navigate']);
+  } finally {
+    global.document = previousDocument;
+  }
+});

--- a/tests/editor/wizard-accessibility.test.js
+++ b/tests/editor/wizard-accessibility.test.js
@@ -75,7 +75,15 @@ test('schema regexes are translated for the HTML UnicodeSets pattern mode', () =
     '^[A-Za-z0-9._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}$'
   );
   assert.equal(FormBuilder.toHtmlPattern('^[1-9]+$'), '^[1-9]+$');
+  assert.equal(FormBuilder.toHtmlPattern('^[[:alpha:]]+$'), null);
   assert.equal(FormBuilder.toHtmlPattern('['), null);
+});
+
+test('array removal selects a surviving remove control or falls back to Add', () => {
+  assert.equal(FormBuilder.getRemovalFocusIndex(0, [true, true]), 0);
+  assert.equal(FormBuilder.getRemovalFocusIndex(2, [true, true]), 1);
+  assert.equal(FormBuilder.getRemovalFocusIndex(0, [false]), -1);
+  assert.equal(FormBuilder.getRemovalFocusIndex(0, []), -1);
 });
 
 test('every bundled schema pattern is compatible with native HTML validation', () => {


### PR DESCRIPTION
## What changed

- keep the wizard progress strip horizontally scrollable on narrow screens;
- make the scrollable progress region keyboard reachable and describe the arrow-key interaction;
- allow validation and preview controls to wrap without forcing horizontal overflow;
- move the preview panel into normal flow at tablet widths;
- add focused source and browser regression coverage.

## Scope

This is the responsive-layout follow-up to #196 and is based on the completed editor accessibility work.

Closes #196
